### PR TITLE
Dynamic gallery: switch to working fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <br>
 
-TLDR; Scroll to bottom of page to explore textures, or access the dynamic gallery created by [Lionel Radisson](https://github.com/MAKIO135) at https://observablehq.com/@makio135/matcaps?ui=classic
+TLDR; Scroll to bottom of page to explore textures, or access the dynamic gallery created by [Lionel Radisson](https://github.com/MAKIO135) at https://observablehq.com/d/2c53c7ee9f619740?ui=classic
 
 
   


### PR DESCRIPTION
the original dynamic gallery wasn't running anymore, so here's a fork with the geometry constructors fixed 
and an additional display of the matcap name right below the selection.